### PR TITLE
Add Slack notification workflow for merged PRs

### DIFF
--- a/spring-boot/.github/workflows/notify-slack-on-pr-merge.yaml
+++ b/spring-boot/.github/workflows/notify-slack-on-pr-merge.yaml
@@ -1,0 +1,24 @@
+name: Notify Slack on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR was merged
+        if: github.event.pull_request.merged == true
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_MESSAGE: |
+            ✅ PR Merged!
+            🔗 Repository: `${{ github.repository }}`
+            🛠 Merged by: `${{ github.actor }}`
+            🚀 PR Title: `${{ github.event.pull_request.title }}`
+            📝 PR Description: `${{ github.event.pull_request.body }}`
+            🔗 PR URL: ${{ github.event.pull_request.html_url }}
+          SLACK_USERNAME: "GitHub Actions"
+          SLACK_ICON_EMOJI: ":white_check_mark:"

--- a/spring-boot/src/main/resources/application.yml
+++ b/spring-boot/src/main/resources/application.yml
@@ -14,7 +14,6 @@ spring:
     properties:
       hibernate.format_sql: true
 
-
   flyway:
     enabled: true
     baseline-on-migrate: true


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to notify a Slack channel when a pull request is merged. It includes details such as repository, actor, PR title, description, and URL for better context. Additionally, a redundant newline in the application.yml file was removed for cleanup.