### PR TITLE
Refactor member creation flow and add unit tests

### DIFF
--- a/spring-boot/src/main/java/com/mpc/springboot/member/application/dto/CreateMemberRequest.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/application/dto/CreateMemberRequest.java
@@ -1,0 +1,18 @@
+package com.mpc.springboot.member.application.dto;
+
+import com.mpc.springboot.member.domain.entity.Member;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+import com.mpc.springboot.member.domain.vo.MemberName;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateMemberRequest {
+    private final MemberCode code;
+    private final MemberName name;
+
+    public Member toEntity() {
+        return Member.of(code, name);
+    }
+}

--- a/spring-boot/src/main/java/com/mpc/springboot/member/application/service/MemberService.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/application/service/MemberService.java
@@ -3,6 +3,7 @@ package com.mpc.springboot.member.application.service;
 import jakarta.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
+import com.mpc.springboot.member.application.dto.CreateMemberRequest;
 import com.mpc.springboot.member.application.dto.MemberResponse;
 import com.mpc.springboot.member.domain.entity.Member;
 import com.mpc.springboot.member.domain.exception.MemberNotFoundException;
@@ -23,7 +24,9 @@ public class MemberService {
     }
 
     @Transactional
-    public Member createMember(Member member) {
-        return memberRepository.save(member);
+    public MemberResponse createMember(CreateMemberRequest request) {
+        Member member = request.toEntity();
+        Member saved = memberRepository.save(member);
+        return MemberResponse.from(saved);
     }
 }

--- a/spring-boot/src/main/java/com/mpc/springboot/member/domain/entity/Member.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/domain/entity/Member.java
@@ -26,7 +26,7 @@ public class Member {
     private MemberName name;
 
     @Embedded
-    private AuditFields auditFields = new AuditFields();
+    private final AuditFields auditFields = new AuditFields();
 
     private Member(MemberCode code, MemberName name) {
         this.code = code;

--- a/spring-boot/src/main/java/com/mpc/springboot/member/domain/mapping/MemberCodeConverter.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/domain/mapping/MemberCodeConverter.java
@@ -21,6 +21,6 @@ public class MemberCodeConverter implements AttributeConverter<MemberCode, Strin
     @Override
     public MemberCode convertToEntityAttribute(String dbData) {
         String value = Objects.requireNonNullElse(dbData, "");
-        return new MemberCode(value);
+        return MemberCode.of(value);
     }
 }

--- a/spring-boot/src/main/java/com/mpc/springboot/member/domain/vo/MemberCode.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/domain/vo/MemberCode.java
@@ -1,10 +1,9 @@
 package com.mpc.springboot.member.domain.vo;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberCode {
     private final String value;
 

--- a/spring-boot/src/main/java/com/mpc/springboot/member/presentation/controller/MemberRestController.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/presentation/controller/MemberRestController.java
@@ -2,6 +2,7 @@ package com.mpc.springboot.member.presentation.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.mpc.springboot.member.application.dto.CreateMemberRequest;
 import com.mpc.springboot.member.application.dto.MemberResponse;
 import com.mpc.springboot.member.application.service.MemberService;
 import com.mpc.springboot.member.domain.entity.Member;
@@ -21,7 +22,7 @@ public class MemberRestController {
     }
 
     @PostMapping
-    public ResponseEntity<Member> createMember(@RequestBody Member member) {
-        return ResponseEntity.ok(memberService.createMember(member));
+    public ResponseEntity<MemberResponse> createMember(@RequestBody CreateMemberRequest request) {
+        return ResponseEntity.ok(memberService.createMember(request));
     }
 }

--- a/spring-boot/src/test/java/com/mpc/springboot/member/application/service/MemberServiceTest.java
+++ b/spring-boot/src/test/java/com/mpc/springboot/member/application/service/MemberServiceTest.java
@@ -1,0 +1,51 @@
+package com.mpc.springboot.member.application.service;
+
+import java.util.Optional;
+
+import com.mpc.springboot.member.application.dto.MemberResponse;
+import com.mpc.springboot.member.domain.entity.Member;
+import com.mpc.springboot.member.domain.repository.MemberRepository;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+import com.mpc.springboot.member.domain.vo.MemberName;
+import com.mpc.springboot.shared.AbstractServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+class MemberServiceTest extends AbstractServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @DisplayName("멤버 조회 테스트")
+    @Test
+    void getMemberBy() {
+        // given
+        MemberCode code = MemberCode.of("M0000016");
+        MemberName name = MemberName.of("Jinwoo", "Kim");
+        Member member = Member.of(code, name);
+        Optional<Member> memberOptional = Optional.of(member);
+
+        given(memberRepository.findMemberBy(any())).willReturn(memberOptional);
+
+        // when
+        MemberResponse memberResponse = memberService.getMemberBy(code);
+
+        // then
+        assertNotNull(memberResponse);
+        assertEquals(code, memberResponse.getCode());
+        assertEquals(name, memberResponse.getName());
+    }
+
+    @Test
+    void createMember() {
+    }
+}

--- a/spring-boot/src/test/java/com/mpc/springboot/member/infrastructure/persistence/jpa/repository/MemberRepositoryTest.java
+++ b/spring-boot/src/test/java/com/mpc/springboot/member/infrastructure/persistence/jpa/repository/MemberRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.mpc.springboot.member.infrastructure.persistence.jpa.repository;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.mpc.springboot.member.domain.entity.Member;
+import com.mpc.springboot.member.domain.repository.MemberRepository;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+import com.mpc.springboot.member.domain.vo.MemberName;
+import com.mpc.springboot.shared.AbstractRepositoryTest;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member savedMember;
+
+    @Override
+    protected void setUp() {
+        // given
+        MemberCode code = MemberCode.of("T0000001");
+        MemberName name = MemberName.of("Alice", "Smith");
+        savedMember = memberRepository.save(Member.of(code, name));
+    }
+
+    @DisplayName("멤버 저장 테스트")
+    @Tag(NO_SETUP)
+    @Test
+    void save() {
+        // given
+        MemberCode code = MemberCode.of("T0000001");
+        MemberName name = MemberName.of("Alice", "Smith");
+        Member member = Member.of(code, name);
+
+        // when
+        Member saved = memberRepository.save(member);
+
+        // then
+        assertNotNull(saved);
+        assertEquals(code, saved.getCode());
+        assertEquals(name, saved.getName());
+    }
+
+    @Test
+    void findMemberBy() {
+        // given
+        MemberCode code = savedMember.getCode();
+
+        // when
+        Optional<Member> result = memberRepository.findMemberBy(code);
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals(savedMember.getCode(), result.get().getCode());
+        assertEquals(savedMember.getName(), result.get().getName());
+    }
+
+
+}

--- a/spring-boot/src/test/java/com/mpc/springboot/shared/AbstractRepositoryTest.java
+++ b/spring-boot/src/test/java/com/mpc/springboot/shared/AbstractRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.mpc.springboot.shared;
+
+import jakarta.transaction.Transactional;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.*;
+
+@SpringBootTest
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractRepositoryTest {
+
+    protected static final String NO_SETUP = "NoSetup";
+
+    @BeforeEach
+    void commonSetUp(TestInfo testInfo) {
+        if (hasNoSetupTag(testInfo)) {
+            return;
+        }
+        setUp();
+    }
+
+    private static boolean hasNoSetupTag(TestInfo testInfo) {
+        return testInfo.getTags()
+            .contains(NO_SETUP);
+    }
+
+    protected abstract void setUp();
+}

--- a/spring-boot/src/test/java/com/mpc/springboot/shared/AbstractServiceTest.java
+++ b/spring-boot/src/test/java/com/mpc/springboot/shared/AbstractServiceTest.java
@@ -1,0 +1,8 @@
+package com.mpc.springboot.shared;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class AbstractServiceTest {
+}


### PR DESCRIPTION
Updated `MemberService` and `MemberRestController` to utilize `CreateMemberRequest` for a cleaner member creation process. Improved `MemberCode` encapsulation and consistency by introducing controlled factory methods. Added `MemberServiceTest` and `MemberRepositoryTest` to enhance test coverage for service and repository layers.