### PR TITLE
Add custom Jackson serializers/deserializers for Member VO

### DIFF
--- a/spring-boot/src/main/java/com/mpc/springboot/member/application/dto/CreateMemberRequest.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/application/dto/CreateMemberRequest.java
@@ -3,14 +3,18 @@ package com.mpc.springboot.member.application.dto;
 import com.mpc.springboot.member.domain.entity.Member;
 import com.mpc.springboot.member.domain.vo.MemberCode;
 import com.mpc.springboot.member.domain.vo.MemberName;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class CreateMemberRequest {
-    private final MemberCode code;
-    private final MemberName name;
+    private MemberCode code;
+    private MemberName name;
+
+    public CreateMemberRequest(MemberCode code, MemberName name) {
+        this.code = code;
+        this.name = name;
+    }
 
     public Member toEntity() {
         return Member.of(code, name);

--- a/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/JacksonConfig.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.mpc.springboot.member.infrastructure.serialization.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+import com.mpc.springboot.member.domain.vo.MemberName;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customJackson() {
+        return builder -> {
+            SimpleModule module = new SimpleModule();
+            module.addSerializer(MemberCode.class, new MemberCodeSerializer());
+            builder.modules(module);
+        };
+    }
+}

--- a/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/MemberCodeDeserializer.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/MemberCodeDeserializer.java
@@ -1,0 +1,14 @@
+package com.mpc.springboot.member.infrastructure.serialization.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+
+public class MemberCodeDeserializer extends JsonDeserializer<MemberCode> {
+    @Override
+    public MemberCode deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return MemberCode.of(p.getText());
+    }
+}

--- a/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/MemberCodeSerializer.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/MemberCodeSerializer.java
@@ -1,0 +1,15 @@
+package com.mpc.springboot.member.infrastructure.serialization.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+
+public class MemberCodeSerializer extends JsonSerializer<MemberCode> {
+    @Override
+    public void serialize(MemberCode value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(value.getValue());
+    }
+}

--- a/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/MemberNameDeserializer.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/infrastructure/serialization/jackson/MemberNameDeserializer.java
@@ -1,0 +1,23 @@
+package com.mpc.springboot.member.infrastructure.serialization.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mpc.springboot.member.domain.vo.MemberName;
+
+import java.io.IOException;
+
+public class MemberNameDeserializer extends JsonDeserializer<MemberName> {
+    @Override
+    public MemberName deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+
+        // JSON의 루트에서 firstName, lastName 가져오기
+        String firstName = node.has("firstName") ? node.get("firstName").asText() : "";
+        String lastName = node.has("lastName") ? node.get("lastName").asText() : "";
+
+        return MemberName.of(firstName, lastName);
+    }
+}

--- a/spring-boot/src/main/java/com/mpc/springboot/member/presentation/converter/MemberCodeConverter.java
+++ b/spring-boot/src/main/java/com/mpc/springboot/member/presentation/converter/MemberCodeConverter.java
@@ -1,0 +1,13 @@
+package com.mpc.springboot.member.presentation.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import com.mpc.springboot.member.domain.vo.MemberCode;
+
+@Component
+public class MemberCodeConverter implements Converter<String, MemberCode> {
+    @Override
+    public MemberCode convert(String source) {
+        return MemberCode.of(source);
+    }
+}


### PR DESCRIPTION
Introduce custom serializers and deserializers for `MemberCode` and `MemberName` using Jackson to handle VO (Value Object) serialization and deserialization. Added a new `MemberCodeConverter` for String to `MemberCode` conversions and adjusted `CreateMemberRequest` for better mutability and deserialization support. This enhances JSON handling in the member infrastructure.